### PR TITLE
Add handling of TFormula fParams & fClingParameters

### DIFF
--- a/scripts/JSRootCore.js
+++ b/scripts/JSRootCore.js
@@ -1588,6 +1588,12 @@
                     _func = this.fFormula.fFormula;
                     pprefix = "[p";
                  }
+                 if (this.fFormula.fClingParameters && this.fFormula.fParams) {
+                    for (var i=0;i<this.fFormula.fParams.length;++i) {
+                       var regex = new RegExp('(\\[' + this.fFormula.fParams[i].first + '\\])', 'g');
+                       _func = _func.replace(regex, this.fFormula.fClingParameters[this.fFormula.fParams[i].second]);
+                    }
+                 }
               }
 
               if ('formulas' in this)


### PR DESCRIPTION
This makes the following example working:

TF1 f1("f1","gaus",0,10);
TF1 f2("f2","10.-x",0,10);
f2.SetParameter(0,1);

f1.SetParameter(0,2);
f1.SetParameter(1,4);
f1.SetParameter(2,2.5);

TF1 f3("f3","f1+f2",0,10);
f3.SetParameter(0,3);
f3.SetParameter(2,0.5);
f3.Draw();

And this should also be applied to what will become the next patch release...