### PR TITLE
Mostly adding Graph support to TTree.Draw

### DIFF
--- a/scripts/JSRootPainter.more.js
+++ b/scripts/JSRootPainter.more.js
@@ -3159,8 +3159,6 @@
          histo.fXaxis.fXmin = uxmin;
          histo.fXaxis.fXmax = uxmax;
 
-         //I think it's probably a good idea to save it? Real ROOT does something like this, I think. 
-         mgraph.fHistogram = histo; 
      }
  
       histo.fYaxis.fXmin = minimum;

--- a/scripts/JSRootPainter.more.js
+++ b/scripts/JSRootPainter.more.js
@@ -3158,8 +3158,11 @@
          histo.fTitle = mgraph.fTitle;
          histo.fXaxis.fXmin = uxmin;
          histo.fXaxis.fXmax = uxmax;
-      }
 
+         //I think it's probably a good idea to save it? Real ROOT does something like this, I think. 
+         mgraph.fHistogram = histo; 
+     }
+ 
       histo.fYaxis.fXmin = minimum;
       histo.fYaxis.fXmax = maximum;
 

--- a/scripts/JSRootTree.js
+++ b/scripts/JSRootTree.js
@@ -606,7 +606,7 @@
                args.drawopt = parvalue;
                break;
             case "graph": 
-               if (intvalue) this.graph = intvalue; 
+               if (intvalue) args.graph = intvalue; 
                break; 
          }
       }
@@ -624,7 +624,7 @@
             args.dump = true;
          } else if (harg.indexOf("Graph") == 0)
          {
-           this.graph = true; 
+           args.graph = true; 
          }
          else if (pos<0) {
             this.hist_name = harg;
@@ -711,6 +711,8 @@
       if (is_direct) this.ProcessArrays = this.ProcessArraysFunc;
 
       this.monitoring = args.monitoring;
+
+      this.graph = args.graph; 
 
       if (args.drawopt !== undefined)
          this.histo_drawopt = args.drawopt;

--- a/scripts/JSRootTree.js
+++ b/scripts/JSRootTree.js
@@ -1175,10 +1175,13 @@
 
       this.globals.entry = entry; // can be used in any expression
 
+      this.cut.Produce(this.tgtobj);
+
+      if (this.cut.value == 0) return; 
+
       for (var n=0;n<this.ndim;++n)
          this.vars[n].Produce(this.tgtobj);
 
-      this.cut.Produce(this.tgtobj);
 
       var var0 = this.vars[0], var1 = this.vars[1], var2 = this.vars[2], cut = this.cut;
 

--- a/scripts/JSRootTree.js
+++ b/scripts/JSRootTree.js
@@ -951,6 +951,7 @@
         else if(this.ndim == 2) 
         {
            this.hist = JSROOT.CreateTGraph(N,this.vars[0].buf, this.vars[1].buf); 
+           delete this.vars[1].buf; 
         }
 
         this.hist.fTitle = this.hist_title; 

--- a/scripts/JSRootTree.js
+++ b/scripts/JSRootTree.js
@@ -872,6 +872,8 @@
          res.max = this.hist_args[axisid*3+2];
       } else {
 
+         
+
          res.min = Math.min.apply(null, arr);
          res.max = Math.max.apply(null, arr);
 
@@ -1147,7 +1149,7 @@
 
       var var0 = this.vars[0], var1 = this.vars[1], var2 = this.vars[2], cut = this.cut;
 
-      if (this.arr_limit) {
+      if (this.arr_limit && cut.value != 0) {
          switch(this.ndim) {
             case 1:
               for (var n0=0;n0<var0.length;++n0) {

--- a/scripts/JSRootTree.js
+++ b/scripts/JSRootTree.js
@@ -534,6 +534,7 @@
       this.histo_drawopt = "";
       this.hist_name = "$htemp";
       this.hist_title = "Result of TTree::Draw";
+      this.graph = false; 
       this.hist_args = []; // arguments for histogram creation
       this.arr_limit = 1000;  // number of accumulated items before create histogram
       this.htype = "F";
@@ -604,6 +605,9 @@
             case "drawopt":
                args.drawopt = parvalue;
                break;
+            case "graph": 
+               if (intvalue) this.graph = intvalue; 
+               break; 
          }
       }
 
@@ -618,7 +622,11 @@
          }
          if (harg === "dump") {
             args.dump = true;
-         } else if (pos<0) {
+         } else if (harg.indexOf("Graph") == 0)
+         {
+           this.graph = true; 
+         }
+         else if (pos<0) {
             this.hist_name = harg;
          } else  if ((harg[0]=="(") && (harg[harg.length-1]==")"))  {
             harg = harg.substr(1,harg.length-2).split(",");
@@ -926,6 +934,26 @@
 
          // reassign fill method
          this.Fill1DHistogram = this.Fill2DHistogram = this.Fill3DHistogram = this.DumpValue;
+      } else if (this.graph) 
+      {
+        var N = this.vars[0].buf.length; 
+
+        if(this.ndim == 1)
+        {
+          // A 1-dimensional graph will just have the x axis as an index
+
+          this.hist = JSROOT.CreateTGraph(N, Array.from(Array(N).keys()), this.vars[0].buf);
+
+
+        }
+        else if(this.ndim == 2) 
+        {
+           this.hist = JSROOT.CreateTGraph(N,this.vars[0].buf, this.vars[1].buf); 
+        }
+
+        this.hist.fTitle = this.hist_title; 
+        this.hist.fName = "Graph"; 
+     
       } else {
 
          this.x = this.GetMinMaxBins(0, (this.ndim > 1) ? 50 : 200);
@@ -962,24 +990,27 @@
 
       var var0 = this.vars[0].buf, cut = this.cut.buf, len = var0.length;
 
-      switch (this.ndim) {
-         case 1:
-            for (var n=0;n<len;++n)
-               this.Fill1DHistogram(var0[n], cut ? cut[n] : 1.);
-            break;
-         case 2:
-            var var1 = this.vars[1].buf;
-            for (var n=0;n<len;++n)
-               this.Fill2DHistogram(var0[n], var1[n], cut ? cut[n] : 1.);
-            delete this.vars[1].buf;
-            break;
-         case 3:
-            var var1 = this.vars[1].buf, var2 = this.vars[2].buf;
-            for (var n=0;n<len;++n)
-               this.Fill2DHistogram(var0[n], var1[n], var2[n], cut ? cut[n] : 1.);
-            delete this.vars[1].buf;
-            delete this.vars[2].buf;
-            break;
+      if (!this.graph) 
+      {
+        switch (this.ndim) {
+           case 1:
+              for (var n=0;n<len;++n)
+                 this.Fill1DHistogram(var0[n], cut ? cut[n] : 1.);
+              break;
+           case 2:
+              var var1 = this.vars[1].buf;
+              for (var n=0;n<len;++n)
+                 this.Fill2DHistogram(var0[n], var1[n], cut ? cut[n] : 1.);
+              delete this.vars[1].buf;
+              break;
+           case 3:
+              var var1 = this.vars[1].buf, var2 = this.vars[2].buf;
+              for (var n=0;n<len;++n)
+                 this.Fill2DHistogram(var0[n], var1[n], var2[n], cut ? cut[n] : 1.);
+              delete this.vars[1].buf;
+              delete this.vars[2].buf;
+              break;
+        }
       }
 
       delete this.vars[0].buf;
@@ -1079,7 +1110,7 @@
       // most typical usage - histogramming of single branch
 
 
-      if (this.arr_limit) {
+      if (this.arr_limit || this.graph) {
          var var0 = this.vars[0], len = this.tgtarr.br0.length,
              var1 = this.vars[1], var2 = this.vars[2];
          if ((var0.buf.length===0) && (len>=this.arr_limit)) {
@@ -1097,7 +1128,7 @@
          if (var1) var1.kind = "number";
          if (var2) var2.kind = "number";
          this.cut.buf = null; // do not create buffer for cuts
-         if (var0.buf.length >= this.arr_limit) {
+         if (!this.graph && var0.buf.length >= this.arr_limit) {
             this.CreateHistogram();
             this.arr_limit = 0;
          }
@@ -1149,7 +1180,7 @@
 
       var var0 = this.vars[0], var1 = this.vars[1], var2 = this.vars[2], cut = this.cut;
 
-      if (this.arr_limit && cut.value != 0) {
+      if ((this.graph || this.arr_limit) && cut.value != 0) {
          switch(this.ndim) {
             case 1:
               for (var n0=0;n0<var0.length;++n0) {
@@ -1176,7 +1207,7 @@
                      }
                break;
          }
-         if (var0.buf.length >= this.arr_limit) {
+         if (!this.graph && var0.buf.length >= this.arr_limit) {
             this.CreateHistogram();
             this.arr_limit = 0;
          }


### PR DESCRIPTION
The big thing here is Graph support in TTree.Draw(). You can set graph: 1 in the args to make a TGraph instead of a histogram. If a one-dimensional draw instead of two-dimensional, each entry will plotted against entry number. 

There are a few other small changes: 
  - Modify handling of cuts in Draw code... basically non-passing entries won't be added to the temporary buffer or considered further. 
 - fHistogram gets populated on a TMultiGraph when it is created for drawing the axes. I think real ROOT does this and this allows one to set axis properties on a TMultiGraph with automatically-generated axes. 
