### PR TITLE
Fix 'blob:' URL handling in Chromium

### DIFF
--- a/scripts/JSRootCore.js
+++ b/scripts/JSRootCore.js
@@ -882,7 +882,7 @@
          if (xhr.readyState != 4) return;
 
          if ((xhr.status != 200) && (xhr.status != 206) && !JSROOT.browser.qt5 &&
-               ((xhr.status !== 0) || (url.indexOf("file://")!==0))) {
+               ((xhr.status !== 0) || (url.indexOf("file://")!==0) && (url.indexOf("blob:")!==0))) {
             return callback(null);
          }
 


### PR DESCRIPTION
Testcase is below. Change `0` to `1` in `JSROOT: 0 ? ...` to see the difference.
```html
<!DOCTYPE html>
<html lang="en">
   <head>
      <meta charset="UTF-8">
      <meta http-equiv="X-UA-Compatible" content="IE=edge">
      <title>Read a ROOT file</title>
      <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.2.0/require.min.js"></script>
      <script>
         require.config({
            paths: {
               JSROOT: 0 ? 'https://cdn.jsdelivr.net/gh/PEERCRED/jsroot@patch-1/scripts/JSRootCore'
                         : 'https://root.cern.ch/js/5.6.1/scripts/JSRootCore',
               domReady: "https://cdnjs.cloudflare.com/ajax/libs/require-domReady/2.0.1/domReady.min"
            }
         });
      </script>
      <script>
         require(['domReady!', 'JSROOT'], function (doc, JSROOT) {
            JSROOT.gStyle.IgnoreUrlOptions = true;

            JSROOT.AssertPrerequisites("2d;hierarchy;jq2d;", function () {
               const d3 = require('d3');

               fetch('https://root.cern/js/files/hsimple.root')
               .then(res => res.blob())
               .then(blob => {
                  let objectURL = URL.createObjectURL(blob);

                  const div = d3.select('#simplexGUI');
                  div.attr('file', objectURL);

                  let hpainter = new JSROOT.HierarchyPainter('complexGUI', 'complexGUI');
                  hpainter.is_online = false;
                  hpainter.StartGUI(div, hpainter.InitializeBrowser.bind(hpainter));
               });
            });
         });
      </script>
   </head>
   <body>
      <div id="simplexGUI" file="" noselect></div>
   </body>
</html>
```