### PR TITLE
Fix example geomsvg.js not working on current version

### DIFF
--- a/demo/node/geomsvg.js
+++ b/demo/node/geomsvg.js
@@ -8,5 +8,5 @@ console.log('JSROOT version', jsroot.version);
 // r3d_svg uses SVGRenderer, can produce large output
 
 jsroot.httpRequest("https://root.cern/js/files/geom/simple_alice.json.gz", 'object')
-      .then(obj => jsroot.MakeSVG({ object: obj, width: 1200, height: 800 /*, option: "r3d_svg" */ }))
+      .then(obj => jsroot.makeSVG({ object: obj, width: 1200, height: 800 /*, option: "r3d_svg" */ }))
       .then(svg => { fs.writeFileSync("alice_geom.svg", svg); console.log(`Create alice_geom.svg size ${svg.length}`); });


### PR DESCRIPTION
`MakeSVG` function seems to be deprecated, should instead use `makeSVG`. This example doesn't run on my install (latest, from `npm install jsroot`) unless I make the change (`JSROOT version 6.0.1 1/03/2021`)

Before the change:
```
PS C:\WSL-Ubuntu-20.04\github\test> node .\app.js
JSROOT version 6.0.1 1/03/2021
C:\WSL-Ubuntu-20.04\github\test\app.js:11
      .then(obj => jsroot.MakeSVG({ object: obj, width: 1200, height: 800 /*, option: "r3d_svg" */ }))
                          ^

TypeError: jsroot.MakeSVG is not a function
    at C:\WSL-Ubuntu-20.04\github\test\app.js:11:27
    at processTicksAndRejections (node:internal/process/task_queues:94:5)
PS C:\WSL-Ubuntu-20.04\github\test> 
```

After the change:

```
PS C:\WSL-Ubuntu-20.04\github\test> node .\app.js     
JSROOT version 6.0.1 1/03/2021
Reuse existing d3.js version 6.6.2, expected 6.1.1
Creating clones 165 takes 5 uniquevis 62
Total visible nodes 62 numfaces 11448
Create tm = 3 meshes 62 faces 11040
three.js r121, first render tm = 429
Create alice_geom.svg size 155976
PS C:\WSL-Ubuntu-20.04\github\test>
```