### PR TITLE
Rearrange bytes from split format to normal format for Unsigned Column types

### DIFF
--- a/modules/rntuple.mjs
+++ b/modules/rntuple.mjs
@@ -179,8 +179,6 @@ function getTypeByteSize(coltype) {
         case ENTupleColumnType.kInt8:
         case ENTupleColumnType.kUInt8:
         case ENTupleColumnType.kByte:
-        case ENTupleColumnType.kByteArray:
-        case ENTupleColumnType.kIndexArrayU8:
         case ENTupleColumnType.kChar:
             return 1;
         default:
@@ -198,8 +196,9 @@ function recontructUnsplitBuffer(blob, columnDescriptor) {
         coltype === ENTupleColumnType.kSplitUInt16 ||
         coltype === ENTupleColumnType.kSplitUInt32 ||
         coltype === ENTupleColumnType.kSplitUInt64 ||
-        coltype === ENTupleColumnType.kSplitIndex64 ||
-        coltype === ENTupleColumnType.kSplitUInt32
+        coltype === ENTupleColumnType.kSplitReal16 ||
+        coltype === ENTupleColumnType.kSplitReal32 ||
+        coltype === ENTupleColumnType.kSplitReal64
     ) {
         const byteSize = getTypeByteSize(coltype),
               splitView = new DataView(blob.buffer, blob.byteOffset, blob.byteLength),
@@ -234,6 +233,15 @@ function recontructUnsplitBuffer(blob, columnDescriptor) {
                   break;
                 case ENTupleColumnType.kSplitIndex64:
                   newColtype = ENTupleColumnType.kIndex64;
+                  break;
+                case ENTupleColumnType.kSplitReal16:
+                  newColtype = ENTupleColumnType.kReal16;
+                  break;
+                case ENTupleColumnType.kSplitReal32:
+                  newColtype = ENTupleColumnType.kReal32;
+                  break;
+                case ENTupleColumnType.kSplitReal64:
+                  newColtype = ENTupleColumnType.kReal64;
                   break;
                 default:
                   throw new Error(`Unsupported split coltype for reassembly: ${coltype}`);


### PR DESCRIPTION
In this commit I can successfuly deserialise` unsigned slip columns `
In the below image you can see the test I ran for compressed `ntpl001_staff.root `file where I checked for flag what was unsigned integer split column which is successfully deserialised but for other fields (e.g Nation) which is not unsigned I get the the error as expected.
<img width="1031" height="623" alt="Screenshot 2025-07-31 121619" src="https://github.com/user-attachments/assets/37c654d0-6946-4f5a-9402-684a78c0c399" />
