### PR TITLE
Implement `build3d()` function

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -3,6 +3,7 @@
 ## Changes in dev
 1. RNtuple support, thanks to Kriti Mahajan (https://github.com/Krmjn09)
 1. Implement RTreeMapPainter to display RNTuple structure, thanks to Patryk Pilichowski (https://github.com/magnustymoteus)
+1. Implement `build3d` function for supported classes #368
 1. Let use hex colors in histogram draw options like "fill_00ff00" or "line_77aa1166"
 1. Let configure exact axis ticks position via draw option like "xticks:[-3,-1,1,3]"
 1. Support gStyle.fBarOffset for `TGraph` bar drawing

--- a/demo/hist_build3d.htm
+++ b/demo/hist_build3d.htm
@@ -23,7 +23,7 @@
 
    <script type='module'>
 
-      import { decodeUrl, httpRequest, openFile, build3d } from 'jsroot';
+      import { decodeUrl, httpRequest, openFile, treeDraw, build3d } from 'jsroot';
 
       import { Box3, Vector3, PerspectiveCamera, Scene, AmbientLight, DirectionalLight, DoubleSide,
                MeshLambertMaterial, Mesh, TetrahedronGeometry, WebGLRenderer } from 'three';
@@ -69,6 +69,7 @@
        camera = new PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, draw_size*5 );
        camera.position.y = draw_size*2;
        camera.position.z = draw_size/2;
+       camera.far = draw_size * 5;
        camera.up.set(0, 0, 1); // z scale up
 
        scene = new Scene();
@@ -77,12 +78,6 @@
        let light = new DirectionalLight( 0xffffff );
        light.position.set(0, 1, 0);
        scene.add( light );
-
-       // first draw dummy object, seen in the beginning
-       let material = new MeshLambertMaterial({side: DoubleSide, color: 'red', vertexColors: false});
-       dummy = new Mesh(new TetrahedronGeometry(75, 0), material);
-       // object.position.set( 200, 0, 200 );
-       scene.add( dummy );
 
        renderer = new WebGLRenderer({ antialias: true });
        renderer.setPixelRatio( window.devicePixelRatio );
@@ -99,21 +94,23 @@
        let filename = 'https://root.cern/js/files/hsimple.root';
 
        let file = await openFile(filename);
-       let obj = await file.readObject('hpxpy');
-
-       let obj3d = await build3d(obj, 'lego2');
+       let hist2 = await file.readObject('hpxpy');
+       let obj3d = await build3d(hist2, 'lego2');
 
        if (obj3d) {
-          scene.remove( dummy );
           scene.add( obj3d );
+          obj3d.position.x = 300;
+          camera.updateProjectionMatrix();
+       }
 
-          let box3 = new Box3().setFromObject(obj3d);
+       let tuple = await file.readObject('ntuple');
+       let hist3 = await treeDraw(tuple, 'px:py:pz;hbins:15');
 
-          draw_size = box3.getSize(new Vector3()).length();
+       obj3d = await build3d(hist3, 'box3');
 
-          scene.position.set(0,0, 0 );
-
-          camera.far = draw_size * 5;
+       if (obj3d) {
+          scene.add( obj3d );
+          obj3d.position.x = -300;
           camera.updateProjectionMatrix();
        }
 

--- a/demo/hist_build3d.htm
+++ b/demo/hist_build3d.htm
@@ -23,7 +23,7 @@
 
    <script type='module'>
 
-      import { decodeUrl, httpRequest, openFile, treeDraw, build3d } from 'jsroot';
+      import { decodeUrl, httpRequest, create, openFile, treeDraw, build3d } from 'jsroot';
 
       import { Box3, Vector3, PerspectiveCamera, Scene, AmbientLight, DirectionalLight, DoubleSide,
                MeshLambertMaterial, Mesh, TetrahedronGeometry, WebGLRenderer } from 'three';
@@ -46,13 +46,7 @@
       }
 
       function render() {
-
          let timer = Date.now() * 0.0001;
-
-         //camera.position.x = Math.cos(timer)*draw_size;
-         //camera.position.z = Math.sin(timer)*draw_size;
-         //camera.position.y = draw_size;
-
          camera.lookAt( scene.position );
 
          for (let i = 0, l = scene.children.length; i < l; i++) {
@@ -63,67 +57,77 @@
          renderer.render( scene, camera );
       }
 
-       container = document.createElement('div');
-       document.body.appendChild(container);
+      async function create3d(obj, opt, x = 0, lbl = '') {
+         return build3d(obj, opt).then(obj3d => {
+            obj3d.position.x = x;
 
-       camera = new PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, draw_size*5 );
-       camera.position.y = draw_size*2;
-       camera.position.z = draw_size/2;
-       camera.far = draw_size * 5;
-       camera.up.set(0, 0, 1); // z scale up
+            scene.add(obj3d);
 
-       scene = new Scene();
-       scene.add(new AmbientLight(0x404040));
+            const latex = create('TLatex');
+            latex.fTitle = lbl;
+            latex.fTextAlign = 22; // center of text
+            latex.fTextColor = 3; // green
+            latex.fTextSize = 10; // absolute size
 
-       let light = new DirectionalLight( 0xffffff );
-       light.position.set(0, 1, 0);
-       scene.add( light );
+            return build3d(latex);
+         }).then(obj3d => {
+            // latex created in X/Y coordinates
+            obj3d.geometry.rotateX(Math.PI / 2);
 
-       renderer = new WebGLRenderer({ antialias: true });
-       renderer.setPixelRatio( window.devicePixelRatio );
-       renderer.setSize( window.innerWidth, window.innerHeight );
-       renderer.setClearColor('white', 1);
+            obj3d.position.x = x;
+            obj3d.position.z = -100;
+            scene.add(obj3d);
+         });
+      }
 
-       container.appendChild( renderer.domElement );
+      container = document.createElement('div');
+      document.body.appendChild(container);
 
-       stats = new Stats();
-       container.appendChild( stats.dom );
+      camera = new PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, draw_size*5 );
+      camera.position.y = draw_size*2;
+      camera.position.z = draw_size/2;
+      camera.far = draw_size * 5;
+      camera.up.set(0, 0, 1); // z scale up
 
-       window.addEventListener( 'resize', onWindowResize, false );
+      scene = new Scene();
+      scene.add(new AmbientLight(0x404040));
 
-       let filename = 'https://root.cern/js/files/hsimple.root';
+      let light = new DirectionalLight( 0xffffff );
+      light.position.set(0, 1, 0);
+      scene.add( light );
 
-       let file = await openFile(filename);
-       let hist2 = await file.readObject('hpxpy');
-       let obj3d = await build3d(hist2, 'lego2');
+      renderer = new WebGLRenderer({ antialias: true });
+      renderer.setPixelRatio( window.devicePixelRatio );
+      renderer.setSize( window.innerWidth, window.innerHeight );
+      renderer.setClearColor('white', 1);
 
-       if (obj3d) {
-          scene.add( obj3d );
-          obj3d.position.x = 0;
-          camera.updateProjectionMatrix();
-       }
+      container.appendChild( renderer.domElement );
 
-       let tuple = await file.readObject('ntuple');
-       let hist3 = await treeDraw(tuple, 'px:py:pz;hbins:15');
+      stats = new Stats();
+      container.appendChild( stats.dom );
 
-       obj3d = await build3d(hist3, 'box3');
+      window.addEventListener( 'resize', onWindowResize, false );
 
-       if (obj3d) {
-          scene.add( obj3d );
-          obj3d.position.x = -400;
-          camera.updateProjectionMatrix();
-       }
+      let filename = 'https://root.cern/js/files/hsimple.root';
 
-       let hist1 = await file.readObject('hpx');
-       obj3d = await build3d(hist1, 'lego2');
-       if (obj3d) {
-          scene.add( obj3d );
-          obj3d.position.x = 400;
-          camera.updateProjectionMatrix();
-       }
+      let file = await openFile(filename);
+      let hist2 = await file.readObject('hpxpy');
+
+      await create3d(hist2, 'lego2', 0, 'TH2 lego plot');
+
+      let tuple = await file.readObject('ntuple');
+      let hist3 = await treeDraw(tuple, 'px:py:pz;hbins:15');
+
+      await create3d(hist3, 'box3', -400, 'TH3 box plot');
+
+      let hist1 = await file.readObject('hpx');
+
+      await create3d(hist1, 'lego2', 400, 'TH1 lego plot');
 
 
-       animate();
+      camera.updateProjectionMatrix();
+
+      animate();
 
    </script>
 

--- a/demo/hist_build3d.htm
+++ b/demo/hist_build3d.htm
@@ -57,9 +57,11 @@
          renderer.render( scene, camera );
       }
 
-      async function create3d(obj, opt, x = 0, lbl = '') {
+      async function create3d(obj, opt, x = 0, lbl = '', scale = 1) {
          return build3d(obj, opt).then(obj3d => {
             obj3d.position.x = x;
+            if (scale !== 1)
+               obj3d.scale.set(scale, scale, scale);
 
             scene.add(obj3d);
 
@@ -70,13 +72,13 @@
             latex.fTextSize = 10; // absolute size
 
             return build3d(latex);
-         }).then(obj3d => {
-            // latex created in X/Y coordinates
-            obj3d.geometry.rotateX(Math.PI / 2);
+         }).then(text3d => {
+            // latex created in X/Y coordinates,
+            text3d.traverse(obj3d => obj3d.geometry?.rotateX(Math.PI / 2));
 
-            obj3d.position.x = x;
-            obj3d.position.z = -100;
-            scene.add(obj3d);
+            text3d.position.x = x;
+            text3d.position.z = -100;
+            scene.add(text3d);
          });
       }
 
@@ -108,22 +110,30 @@
 
       window.addEventListener( 'resize', onWindowResize, false );
 
-      let filename = 'https://root.cern/js/files/hsimple.root';
+      let filename = 'https://root.cern/js/files/hsimple.root',
+          filename2 = 'https://jsroot.gsi.de/files/graph2d.root';
 
       let file = await openFile(filename);
       let hist2 = await file.readObject('hpxpy');
 
-      await create3d(hist2, 'lego2', 0, 'TH2 lego plot');
+      await create3d(hist2, 'lego2', 150, '#color[2]{TH2} #color[4]{lego} plot');
 
       let tuple = await file.readObject('ntuple');
       let hist3 = await treeDraw(tuple, 'px:py:pz;hbins:15');
 
-      await create3d(hist3, 'box3', -400, 'TH3 box plot');
+      await create3d(hist3, 'box3', -150, '#color[2]{TH3} #color[4]{box} plot');
 
       let hist1 = await file.readObject('hpx');
 
-      await create3d(hist1, 'lego2', 400, 'TH1 lego plot');
+      await create3d(hist1, 'lego2', 400, '#color[2]{TH1} #color[4]{lego} plot');
 
+      let geom = await httpRequest('https://root.cern/js/files/geom/simple_alice.json.gz', 'object');
+      await create3d(geom, '', -400, '#color[2]{Geometry} build', 0.2);
+
+      let file2 = await openFile(filename2);
+      let gr2 = await file2.readObject('Graph2D');
+
+      await create3d(gr2, 'p', 650, '#color[2]{TGraph2D} drawing with #color[4]{p}');
 
       camera.updateProjectionMatrix();
 

--- a/demo/hist_build3d.htm
+++ b/demo/hist_build3d.htm
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+   <head>
+      <title>three.js model for histogram objects</title>
+      <meta charset="utf-8">
+      <link rel="shortcut icon" href="../img/RootIcon.ico"/>
+      <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+      <style>
+         body {
+            font-family: Monospace;
+            background-color: #000;
+            margin: 0px;
+            overflow: hidden;
+         }
+      </style>
+      <script type="importmap">
+         { "imports": { "jsroot": "../modules/main.mjs", "jsroot/hist2": "../modules/hist/TH2Painter.mjs", "three": "../modules/three.mjs" } }
+      </script>
+   </head>
+
+   <body>
+   </body>
+
+   <script type='module'>
+
+      import { decodeUrl, httpRequest, openFile } from 'jsroot';
+
+      import { Box3, Vector3, PerspectiveCamera, Scene, AmbientLight, DirectionalLight, DoubleSide,
+               MeshLambertMaterial, Mesh, TetrahedronGeometry, WebGLRenderer } from 'three';
+
+      import { TH2Painter } from 'jsroot/hist2';
+
+      import Stats from 'https://threejs.org/examples/jsm/libs/stats.module.js';
+
+      let container, stats,  camera, scene, renderer, draw_size = 400, dummy = null,
+         d = decodeUrl();
+
+      function onWindowResize() {
+         camera.aspect = window.innerWidth / window.innerHeight;
+         camera.updateProjectionMatrix();
+         renderer.setSize( window.innerWidth, window.innerHeight );
+      }
+
+      function animate() {
+         requestAnimationFrame( animate );
+         render();
+         stats.update();
+      }
+
+      function render() {
+
+         let timer = Date.now() * 0.0001;
+
+         //camera.position.x = Math.cos(timer)*draw_size;
+         //camera.position.z = Math.sin(timer)*draw_size;
+         //camera.position.y = draw_size;
+
+         camera.lookAt( scene.position );
+
+         for (let i = 0, l = scene.children.length; i < l; i++) {
+            let object = scene.children[ i ];
+            object.rotation.z = timer * 5;
+         }
+
+         renderer.render( scene, camera );
+      }
+
+       container = document.createElement('div');
+       document.body.appendChild(container);
+
+       camera = new PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, draw_size*5 );
+       camera.position.y = draw_size*2;
+       camera.position.z = draw_size/2;
+       camera.up.set(0, 0, 1); // z scale up
+
+       scene = new Scene();
+       scene.add(new AmbientLight(0x404040));
+
+       let light = new DirectionalLight( 0xffffff );
+       light.position.set(0, 1, 0);
+       scene.add( light );
+
+       // first draw dummy object, seen in the beginning
+       let material = new MeshLambertMaterial({side: DoubleSide, color: 'red', vertexColors: false});
+       dummy = new Mesh(new TetrahedronGeometry(75, 0), material);
+       // object.position.set( 200, 0, 200 );
+       scene.add( dummy );
+
+       renderer = new WebGLRenderer({ antialias: true });
+       renderer.setPixelRatio( window.devicePixelRatio );
+       renderer.setSize( window.innerWidth, window.innerHeight );
+       renderer.setClearColor('white', 1);
+
+       container.appendChild( renderer.domElement );
+
+       stats = new Stats();
+       container.appendChild( stats.dom );
+
+       window.addEventListener( 'resize', onWindowResize, false );
+
+       let filename = 'https://root.cern/js/files/hsimple.root';
+
+       let file = await openFile(filename);
+       let obj = await file.readObject('hpxpy');
+
+       let obj3d = await TH2Painter.build3d(obj, 'lego2');
+
+       if (obj3d) {
+          scene.remove( dummy );
+          scene.add( obj3d );
+
+          let box3 = new Box3().setFromObject(obj3d);
+
+          draw_size = box3.getSize(new Vector3()).length();
+
+          scene.position.set(0,0, 0 );
+
+          camera.far = draw_size * 5;
+          camera.updateProjectionMatrix();
+       }
+
+       animate();
+
+   </script>
+
+</html>

--- a/demo/hist_build3d.htm
+++ b/demo/hist_build3d.htm
@@ -99,7 +99,7 @@
 
        if (obj3d) {
           scene.add( obj3d );
-          obj3d.position.x = 300;
+          obj3d.position.x = 0;
           camera.updateProjectionMatrix();
        }
 
@@ -110,9 +110,18 @@
 
        if (obj3d) {
           scene.add( obj3d );
-          obj3d.position.x = -300;
+          obj3d.position.x = -400;
           camera.updateProjectionMatrix();
        }
+
+       let hist1 = await file.readObject('hpx');
+       obj3d = await build3d(hist1, 'lego2');
+       if (obj3d) {
+          scene.add( obj3d );
+          obj3d.position.x = 400;
+          camera.updateProjectionMatrix();
+       }
+
 
        animate();
 

--- a/demo/hist_build3d.htm
+++ b/demo/hist_build3d.htm
@@ -14,7 +14,7 @@
          }
       </style>
       <script type="importmap">
-         { "imports": { "jsroot": "../modules/main.mjs", "jsroot/hist2": "../modules/hist/TH2Painter.mjs", "three": "../modules/three.mjs" } }
+         { "imports": { "jsroot": "../modules/main.mjs", "three": "../modules/three.mjs" } }
       </script>
    </head>
 
@@ -23,12 +23,10 @@
 
    <script type='module'>
 
-      import { decodeUrl, httpRequest, openFile } from 'jsroot';
+      import { decodeUrl, httpRequest, openFile, build3d } from 'jsroot';
 
       import { Box3, Vector3, PerspectiveCamera, Scene, AmbientLight, DirectionalLight, DoubleSide,
                MeshLambertMaterial, Mesh, TetrahedronGeometry, WebGLRenderer } from 'three';
-
-      import { TH2Painter } from 'jsroot/hist2';
 
       import Stats from 'https://threejs.org/examples/jsm/libs/stats.module.js';
 
@@ -103,7 +101,7 @@
        let file = await openFile(filename);
        let obj = await file.readObject('hpxpy');
 
-       let obj3d = await TH2Painter.build3d(obj, 'lego2');
+       let obj3d = await build3d(obj, 'lego2');
 
        if (obj3d) {
           scene.remove( dummy );

--- a/modules/base/base3d.mjs
+++ b/modules/base/base3d.mjs
@@ -229,11 +229,14 @@ function getRender3DKind(render3d, is_batch) {
    if (is_batch === undefined)
       is_batch = isBatchMode();
 
-   if (!render3d) render3d = is_batch ? settings.Render3DBatch : settings.Render3D;
+   if (!render3d)
+      render3d = is_batch ? settings.Render3DBatch : settings.Render3D;
    const rc = constants.Render3D;
 
-   if (render3d === rc.Default) render3d = is_batch ? rc.WebGLImage : rc.WebGL;
-   if (is_batch && (render3d === rc.WebGL)) render3d = rc.WebGLImage;
+   if (render3d === rc.Default)
+      render3d = is_batch ? rc.WebGLImage : rc.WebGL;
+   if (is_batch && (render3d === rc.WebGL))
+      render3d = rc.WebGLImage;
 
    return render3d;
 }
@@ -518,11 +521,14 @@ async function createRender3D(width, height, render3d, args) {
 
    render3d = getRender3DKind(render3d);
 
-   if (!args) args = { antialias: true, alpha: true };
+   if (!args)
+      args = { antialias: true, alpha: true };
 
    let promise;
 
-   if (render3d === rc.SVG) {
+   if (render3d === rc.None)
+      promise = Promise.resolve(null);
+   else if (render3d === rc.SVG) {
       // SVG rendering
       const r = createSVGRenderer(false, 0, doc);
       r.jsroot_dom = doc.createElementNS(nsSVG, 'svg');
@@ -565,6 +571,9 @@ async function createRender3D(width, height, render3d, args) {
    }
 
    return promise.then(renderer => {
+      if (!renderer)
+         return renderer;
+
       if (!renderer.jsroot_dom)
          renderer.jsroot_dom = renderer.domElement;
       else

--- a/modules/core.mjs
+++ b/modules/core.mjs
@@ -4,7 +4,7 @@ const version_id = 'dev',
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-version_date = '25/09/2025',
+version_date = '29/09/2025',
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}

--- a/modules/core.mjs
+++ b/modules/core.mjs
@@ -165,6 +165,8 @@ const constants = {
       WebGLImage: 2,
       /** @summary Use SVG rendering, slow, imprecise and not interactive, not recommended */
       SVG: 3,
+      /** @summary Disable renderer, used for three.js model creation, only for internal use recommended */
+      None: 4,
       fromString(s) {
          if ((s === 'webgl') || (s === 'gl'))
             return this.WebGL;
@@ -172,6 +174,8 @@ const constants = {
             return this.WebGLImage;
          if (s === 'svg')
             return this.SVG;
+         if (s === 'none')
+            return this.None;
          return this.Default;
       }
    },

--- a/modules/draw.mjs
+++ b/modules/draw.mjs
@@ -548,6 +548,27 @@ async function redraw(dom, obj, opt) {
    return draw(dom, obj, opt);
 }
 
+/** @summary Create three.js model for object
+  * @param {object} obj - object
+  * @param {string} opt - draw options
+  * @return {Promise} with three.js model */
+
+async function build3d(obj, opt) {
+   if (!isObject(obj) || !obj?._typename)
+      return Promise.reject(Error('not an object in build3d'));
+
+   const handle = getDrawHandle(getKindForType(obj._typename));
+   if (!handle?.class)
+      return Promise.reject(Error(`not able to create three.js for ${obj._typename}`));
+
+   return handle.class().then(cl => {
+      if (!isFunc(cl?.build3d))
+        return Promise.reject(Error(`painter class for ${obj._typename} does not implement build3d method`));
+
+      return cl.build3d(obj, opt);
+   });
+}
+
 /** @summary Scan streamer infos for derived classes
   * @desc Assign draw functions for such derived classes
   * @private */
@@ -756,4 +777,4 @@ Object.assign(internals, { addStreamerInfosForPainter, addDrawFunc, setDefaultDr
 Object.assign(internals.jsroot, { draw, redraw, makeSVG, makeImage, addDrawFunc });
 
 export { addDrawFunc, getDrawHandle, canDrawHandle, getDrawSettings, setDefaultDrawOpt,
-         draw, redraw, cleanup, makeSVG, makeImage, assignPadPainterDraw };
+         draw, redraw,cleanup,  build3d, makeSVG, makeImage, assignPadPainterDraw };

--- a/modules/draw.mjs
+++ b/modules/draw.mjs
@@ -562,7 +562,7 @@ async function build3d(obj, opt) {
       return Promise.reject(Error(`not able to create three.js for ${obj._typename}`));
 
    if (handle.build3d)
-      return handle.build3d().then(func => func(obj, opt))
+      return handle.build3d().then(func => func(obj, opt));
 
    return handle.class().then(cl => {
       if (!isFunc(cl?.build3d))
@@ -780,4 +780,4 @@ Object.assign(internals, { addStreamerInfosForPainter, addDrawFunc, setDefaultDr
 Object.assign(internals.jsroot, { draw, redraw, makeSVG, makeImage, addDrawFunc });
 
 export { addDrawFunc, getDrawHandle, canDrawHandle, getDrawSettings, setDefaultDrawOpt,
-         draw, redraw,cleanup, build3d, makeSVG, makeImage, assignPadPainterDraw };
+         draw, redraw, cleanup, build3d, makeSVG, makeImage, assignPadPainterDraw };

--- a/modules/draw.mjs
+++ b/modules/draw.mjs
@@ -49,7 +49,7 @@ drawFuncs = { lst: [
    { name: clTDiamond, sameas: clTPave },
    { name: clTLegend, icon: 'img_pavelabel', sameas: clTPave },
    { name: clTPaletteAxis, icon: 'img_colz', sameas: clTPave },
-   { name: clTLatex, icon: 'img_text', draw: () => import_more().then(h => h.drawText), direct: true },
+   { name: clTLatex, icon: 'img_text', draw: () => import_more().then(h => h.drawText), build3d: () => import('./hist/hist3d.mjs').then(h => h.build3dlatex), direct: true },
    { name: clTMathText, sameas: clTLatex },
    { name: clTText, sameas: clTLatex },
    { name: clTLink, sameas: clTText },
@@ -558,8 +558,11 @@ async function build3d(obj, opt) {
       return Promise.reject(Error('not an object in build3d'));
 
    const handle = getDrawHandle(getKindForType(obj._typename));
-   if (!handle?.class)
+   if (!handle?.class && !handle.build3d)
       return Promise.reject(Error(`not able to create three.js for ${obj._typename}`));
+
+   if (handle.build3d)
+      return handle.build3d().then(func => func(obj, opt))
 
    return handle.class().then(cl => {
       if (!isFunc(cl?.build3d))
@@ -777,4 +780,4 @@ Object.assign(internals, { addStreamerInfosForPainter, addDrawFunc, setDefaultDr
 Object.assign(internals.jsroot, { draw, redraw, makeSVG, makeImage, addDrawFunc });
 
 export { addDrawFunc, getDrawHandle, canDrawHandle, getDrawSettings, setDefaultDrawOpt,
-         draw, redraw,cleanup,  build3d, makeSVG, makeImage, assignPadPainterDraw };
+         draw, redraw,cleanup, build3d, makeSVG, makeImage, assignPadPainterDraw };

--- a/modules/geom/TGeoPainter.mjs
+++ b/modules/geom/TGeoPainter.mjs
@@ -5481,15 +5481,14 @@ class TGeoPainter extends ObjectPainter {
       if (!obj)
          return null;
 
-      let opt = null;
+      let opt = sopt || {};
       if (isStr(sopt)) {
          const painter = new TGeoPainter(null, obj);
          painter.decodeOptions(sopt);
          opt = painter.ctrl;
          opt.numfaces = opt.maxfaces;
          opt.numnodes = opt.maxnodes;
-      } else
-         opt = sopt || {};
+      }
 
       if (!opt.numfaces)
          opt.numfaces = 100000;

--- a/modules/hist/TGraph2DPainter.mjs
+++ b/modules/hist/TGraph2DPainter.mjs
@@ -1124,9 +1124,8 @@ class TGraph2DPainter extends ObjectPainter {
          res.Axis = 'lego2';
          if (res.Zscale)
             res.Axis += 'z';
-      } else {
+      } else
          res.Axis = opt;
-      }
 
       this.storeDrawOpt(opt);
    }
@@ -1599,8 +1598,8 @@ class TGraph2DPainter extends ObjectPainter {
          painter.getFramePainter = () => fp;
          painter.getMainPainter = () => hist_painter;
 
-         return painter.drawGraph2D().then(() => fp.create3DScene(-1, true))
-      })
+         return painter.drawGraph2D().then(() => fp.create3DScene(-1, true));
+      });
    }
 
    /** @summary draw TGraph2D object */

--- a/modules/hist/TH1Painter.mjs
+++ b/modules/hist/TH1Painter.mjs
@@ -17,7 +17,6 @@ class TH1Painter extends TH1Painter2D {
 
       const fp = this.getFramePainter(), // who makes axis drawing
             is_main = this.isMainPainter(), // is main histogram
-            histo = this.getHisto(),
             o = this.getOptions();
 
       o.zmult = 1 + 2*gStyle.fHistTopMargin;

--- a/modules/hist/TH1Painter.mjs
+++ b/modules/hist/TH1Painter.mjs
@@ -1,6 +1,7 @@
-import { settings, gStyle } from '../core.mjs';
-import { assignFrame3DMethods, drawBinsLego } from './hist3d.mjs';
+import { gStyle } from '../core.mjs';
+import { crete3DFrame, drawBinsLego } from './hist3d.mjs';
 import { TAxisPainter } from '../gpad/TAxisPainter.mjs';
+import { TFramePainter } from '../gpad/TFramePainter.mjs';
 import { THistPainter } from '../hist2d/THistPainter.mjs';
 import { TH1Painter as TH1Painter2D } from '../hist2d/TH1Painter.mjs';
 
@@ -17,8 +18,9 @@ class TH1Painter extends TH1Painter2D {
       const fp = this.getFramePainter(), // who makes axis drawing
             is_main = this.isMainPainter(), // is main histogram
             histo = this.getHisto(),
-            o = this.getOptions(),
-            zmult = 1 + 2*gStyle.fHistTopMargin;
+            o = this.getOptions();
+
+      o.zmult = 1 + 2*gStyle.fHistTopMargin;
       let pr = Promise.resolve(true), full_draw = true;
 
       if (reason === 'resize') {
@@ -35,17 +37,8 @@ class TH1Painter extends TH1Painter2D {
 
          this.scanContent(reason === 'zoom'); // may be required for axis drawings
 
-         if (is_main) {
-            assignFrame3DMethods(fp);
-            pr = fp.create3DScene(o.Render3D, o.x3dscale, o.y3dscale, o.Ortho).then(() => {
-               fp.setAxesRanges(histo.fXaxis, this.xmin, this.xmax, histo.fYaxis, this.ymin, this.ymax, histo.fZaxis, 0, 0, this);
-               fp.set3DOptions(o);
-               fp.drawXYZ(fp.toplevel, TAxisPainter, {
-                  ndim: 1, hist_painter: this, use_y_for_z: true, zmult, zoom: settings.Zooming,
-                  draw: (o.Axis !== -1), drawany: o.isCartesian()
-               });
-            });
-         }
+         if (is_main)
+            pr = crete3DFrame(this, TAxisPainter, o.Render3D);
 
          if (fp.mode3d) {
             pr = pr.then(() => {
@@ -64,6 +57,24 @@ class TH1Painter extends TH1Painter2D {
                .then(() => this.updateHistTitle())
                .then(() => this);
    }
+
+   /** @summary Build three.js object for the histogram */
+   static async build3d(histo, opt) {
+      const painter = new TH1Painter(null, histo);
+      painter.decodeOptions(opt);
+      painter.scanContent();
+
+      painter.createHistDrawAttributes(true);
+      painter.options.zmult = 1 + 2*gStyle.fHistTopMargin;
+
+      const fp = new TFramePainter(null, null);
+      painter.getFramePainter = () => fp;
+
+      return crete3DFrame(painter, TAxisPainter)
+             .then(() => drawBinsLego(painter))
+             .then(() => fp.create3DScene(-1, true));
+   }
+
 
    /** @summary draw TH1 object */
    static async draw(dom, histo, opt) {

--- a/modules/hist/TH2Painter.mjs
+++ b/modules/hist/TH2Painter.mjs
@@ -1,4 +1,4 @@
-import { settings, gStyle, clTMultiGraph, kNoZoom } from '../core.mjs';
+import { settings, constants, gStyle, clTMultiGraph, kNoZoom } from '../core.mjs';
 import { getMaterialArgs, THREE } from '../base/base3d.mjs';
 import { assignFrame3DMethods, drawBinsLego, drawBinsError3D, drawBinsContour3D, drawBinsSurf3D } from './hist3d.mjs';
 import { TAxisPainter } from '../gpad/TAxisPainter.mjs';
@@ -330,12 +330,12 @@ class TH2Painter extends TH2Painter2D {
       // return dummy frame painter as result
       painter.getFramePainter = () => fp;
 
-      return fp.create3DScene(o.Render3D, o.x3dscale, o.y3dscale, o.Ortho).then(() => {
+      return fp.create3DScene(constants.Render3D.None, o.x3dscale, o.y3dscale, o.Ortho).then(() => {
          fp.setAxesRanges(histo.fXaxis, painter.xmin, painter.xmax, histo.fYaxis, painter.ymin, painter.ymax, histo.fZaxis, painter.zmin, painter.zmax, painter);
          fp.set3DOptions(o);
          fp.drawXYZ(fp.toplevel, TAxisPainter, {
             ndim: 2, hist_painter: painter, zmult, zoom: false,
-            draw: true, drawany: o.isCartesian(),
+            draw: o.Axis !== -1, drawany: o.isCartesian(),
             reverse_x: o.RevX, reverse_y: o.RevY
          });
          if (painter.isTH2Poly())
@@ -349,7 +349,14 @@ class TH2Painter extends TH2Painter2D {
          else
             drawBinsLego(painter);
 
-         return fp.toplevel;
+
+         // correctly cleanup all objects
+         const res3d = fp.toplevel;
+         fp.scene.remove(res3d);
+         fp.toplevel = null;
+         fp.create3DScene(-1);
+
+         return res3d;
       });
    }
 

--- a/modules/hist/TH2Painter.mjs
+++ b/modules/hist/TH2Painter.mjs
@@ -336,13 +336,8 @@ class TH2Painter extends TH2Painter2D {
       return painter.crete3DFrame(fp, constants.Render3D.None, o, histo, zmult).then(() => {
          if (painter.draw_content)
             painter.draw3DBins(o);
-         // correctly cleanup all objects
-         const res3d = fp.toplevel;
-         fp.scene.remove(res3d);
-         fp.toplevel = null;
-         fp.create3DScene(-1);
 
-         return res3d;
+         return fp.create3DScene(-1, true);
       });
    }
 

--- a/modules/hist/TH2Painter.mjs
+++ b/modules/hist/TH2Painter.mjs
@@ -300,7 +300,7 @@ class TH2Painter extends TH2Painter2D {
    }
 
    /** @summary Build three.js object for the histogram */
-   static async build3d(histo, opt) {
+   static async build3d(histo, opt, get_painter) {
       const painter = new TH2Painter(null, histo);
       painter.decodeOptions(opt);
 
@@ -319,7 +319,7 @@ class TH2Painter extends TH2Painter2D {
          if (painter.draw_content)
             painter.draw3DBins(o);
 
-         return fp.create3DScene(-1, true);
+         return get_painter ? painter : fp.create3DScene(-1, true);
       });
    }
 

--- a/modules/hist/TH2Painter.mjs
+++ b/modules/hist/TH2Painter.mjs
@@ -1,4 +1,4 @@
-import { settings, constants, gStyle, clTMultiGraph, kNoZoom } from '../core.mjs';
+import { gStyle, clTMultiGraph, kNoZoom } from '../core.mjs';
 import { getMaterialArgs, THREE } from '../base/base3d.mjs';
 import { crete3DFrame, drawBinsLego, drawBinsError3D, drawBinsContour3D, drawBinsSurf3D } from './hist3d.mjs';
 import { TAxisPainter } from '../gpad/TAxisPainter.mjs';
@@ -244,7 +244,6 @@ class TH2Painter extends TH2Painter2D {
          drawBinsError3D(this);
       else
          drawBinsLego(this);
-
    }
 
    /** @summary draw TH2 object in 3D mode */
@@ -253,7 +252,6 @@ class TH2Painter extends TH2Painter2D {
 
       const fp = this.getFramePainter(), // who makes axis drawing
             is_main = this.isMainPainter(), // is main histogram
-            histo = this.getHisto(),
             o = this.getOptions();
 
       let pr = Promise.resolve(true), full_draw = true;
@@ -304,7 +302,7 @@ class TH2Painter extends TH2Painter2D {
       const painter = new TH2Painter(null, histo);
       painter.decodeOptions(opt);
 
-      const o = painter.getOptions(), logz = false;
+      const o = painter.getOptions();
       if (painter.isTH2Poly())
          o.Lego = 12;
       painter.scanContent();

--- a/modules/hist/TH3Painter.mjs
+++ b/modules/hist/TH3Painter.mjs
@@ -1,4 +1,4 @@
-import { gStyle, settings, kInspect, clTF1, clTF3, clTProfile3D, BIT, isFunc } from '../core.mjs';
+import { gStyle, kInspect, clTF1, clTF3, clTProfile3D, BIT, isFunc } from '../core.mjs';
 import { TRandom, floatToString } from '../base/BasePainter.mjs';
 import { ensureTCanvas } from '../gpad/TCanvasPainter.mjs';
 import { TAxisPainter } from '../gpad/TAxisPainter.mjs';
@@ -636,7 +636,6 @@ class TH3Painter extends THistPainter {
    /** @summary Redraw TH3 histogram */
    async redraw(reason) {
       const fp = this.getFramePainter(), // who makes axis and 3D drawing
-            histo = this.getHisto(),
             o = this.getOptions();
 
       let pr = Promise.resolve(true), full_draw = true;

--- a/modules/hist/hist3d.mjs
+++ b/modules/hist/hist3d.mjs
@@ -510,6 +510,12 @@ function create3DScene(render3d, x3dscale, y3dscale, orthographic) {
          return;
       }
 
+      const res = x3dscale ? this.toplevel : null;
+      if (res) {
+         this.scene?.remove(res);
+         this.toplevel = null;
+      }
+
       testAxisVisibility(null, this.toplevel);
 
       this.clear3dCanvas();
@@ -536,10 +542,10 @@ function create3DScene(render3d, x3dscale, y3dscale, orthographic) {
 
       this.mode3d = false;
 
-      if (this.getG())
+      if (this.getG() && !x3dscale)
          this.createFrameG();
 
-      return;
+      return res;
    }
 
    this.mode3d = true; // indicate 3d mode as hist painter does

--- a/modules/hist/hist3d.mjs
+++ b/modules/hist/hist3d.mjs
@@ -204,7 +204,7 @@ function build3dlatex(obj) {
       geom.computeBoundingBox();
       bb.expandByPoint(geom.boundingBox.max);
       bb.expandByPoint(geom.boundingBox.min);
-   })
+   });
 
    let width = bb.max.x - bb.min.x,
        height = bb.max.y - bb.min.y;
@@ -219,7 +219,8 @@ function build3dlatex(obj) {
    else if (valign === 2)
       height *= 0.5;
 
-   const materials = [],
+   const obj3d = new THREE.Object3D(),
+         materials = [],
          getMaterial = color => {
             if (!color)
                color = 'black';
@@ -227,11 +228,6 @@ function build3dlatex(obj) {
                materials[color] = new THREE.MeshBasicMaterial(getMaterialArgs(color, { vertexColors: false }));
             return materials[color];
          };
-
-
-   const material0 = new THREE.MeshBasicMaterial(getMaterialArgs(handle.color || 'black', { vertexColors: false }));
-
-   const obj3d = new THREE.Object3D();
 
    arr3d.forEach(geom => {
       geom.translate(-width, -height, 0);

--- a/modules/hist/hist3d.mjs
+++ b/modules/hist/hist3d.mjs
@@ -598,6 +598,8 @@ function create3DScene(render3d, x3dscale, y3dscale, orthographic) {
       return createRender3D(this.scene_width, this.scene_height, render3d);
    }).then(r => {
       this.renderer = r;
+      if (!r)
+         return this;
 
       this.webgl = r.jsroot_render3d === constants.Render3D.WebGL;
       this.add3dCanvas(sz, r.jsroot_dom, this.webgl);

--- a/modules/hist/hist3d.mjs
+++ b/modules/hist/hist3d.mjs
@@ -1,4 +1,4 @@
-import { constants, isFunc, isStr, getDocument, isNodeJs } from '../core.mjs';
+import { constants, settings, isFunc, isStr, getDocument, isNodeJs } from '../core.mjs';
 import { rgb as d3_rgb } from '../d3.mjs';
 import { THREE, assign3DHandler, disposeThreejsObject, createOrbitControl,
          createLineSegments, Box3D, getMaterialArgs, importThreeJs,
@@ -1645,6 +1645,33 @@ function assignFrame3DMethods(fp) {
    Object.assign(fp, { create3DScene, add3DMesh, remove3DMeshes, getRenderer, render3D, resize3D, change3DCamera, highlightBin3D, set3DOptions, drawXYZ, convert3DtoPadNDC });
 }
 
+
+/** @summary Create 3D objects in the frame
+  * @private */
+async function crete3DFrame(painter, AxisPainterClass, render3d = constants.Render3D.None) {
+   const fp = painter.getFramePainter(),
+         o = painter.getOptions(),
+         histo = painter.getHisto();
+
+   assignFrame3DMethods(fp);
+
+   return fp.create3DScene(render3d, o.x3dscale, o.y3dscale, o.Ortho).then(() => {
+      fp.setAxesRanges(histo.fXaxis, painter.xmin, painter.xmax, histo.fYaxis, painter.ymin, painter.ymax, histo.fZaxis, painter.zmin, painter.zmax, painter);
+      fp.set3DOptions(o);
+      fp.drawXYZ(fp.toplevel, AxisPainterClass, {
+         ndim: painter.getDimension(),
+         hist_painter: painter,
+         zmult: o.zmult ?? 1,
+         zoom: (render3d !== constants.Render3D.None) && settings.Zooming,
+         draw: o.Axis !== -1,
+         drawany: o.isCartesian(),
+         reverse_x: o.RevX,
+         reverse_y: o.RevY
+      });
+      return fp;
+   });
+}
+
 function _meshLegoToolTip(intersect) {
    if ((intersect.faceIndex < 0) || (intersect.faceIndex >= this.face_to_bins_index.length))
       return null;
@@ -2373,4 +2400,6 @@ function drawBinsSurf3D(painter, is_v7 = false) {
    }
 }
 
-export { assignFrame3DMethods, drawBinsLego, drawBinsError3D, drawBinsContour3D, drawBinsSurf3D, convertLegoBuf, createLegoGeom };
+export { assignFrame3DMethods, crete3DFrame,
+         drawBinsLego, drawBinsError3D, drawBinsContour3D,
+         drawBinsSurf3D, convertLegoBuf, createLegoGeom };

--- a/modules/hist/hist3d.mjs
+++ b/modules/hist/hist3d.mjs
@@ -338,7 +338,7 @@ function create3DCamera(fp, orthographic) {
 /** @summary Returns camera default position
   * @private */
 function getCameraDefaultPosition(fp, first_time) {
-   const pad = fp.getPadPainter().getRootPad(true),
+   const pad = fp.getPadPainter()?.getRootPad(true),
          kz = fp.camera.isOrthographicCamera ? 1 : 1.4;
    let max3dx = Math.max(0.75*fp.size_x3d, fp.size_z3d),
        max3dy = Math.max(0.75*fp.size_y3d, fp.size_z3d),
@@ -891,7 +891,7 @@ function drawXYZ(toplevel, AxisPainter, opts) {
    else
       opts.drawany = true;
 
-   const pad = opts.v7 ? null : this.getPadPainter().getRootPad(true);
+   const pad = opts.v7 ? null : this.getPadPainter()?.getRootPad(true);
    let grminx = -this.size_x3d, grmaxx = this.size_x3d,
        grminy = -this.size_y3d, grmaxy = this.size_y3d,
        grminz = 0, grmaxz = 2*this.size_z3d,

--- a/modules/hist/hist3d.mjs
+++ b/modules/hist/hist3d.mjs
@@ -179,6 +179,19 @@ function createLatexGeometry(painter, lbl, size) {
    return fullgeom;
 }
 
+/** @summary Build three.js object for the TLatex
+  * @private */
+function build3dlatex(obj, opt) {
+   let geom = createLatexGeometry(null, obj.fName, 20);
+
+   let material = new THREE.MeshBasicMaterial(getMaterialArgs('blue', { vertexColors: false }));
+
+   const mesh = new THREE.Mesh(geom, material);
+
+   return mesh;
+}
+
+
 /** @summary Text 3d axis visibility
   * @private */
 function testAxisVisibility(camera, toplevel, fb = false, bb = false) {
@@ -2402,6 +2415,6 @@ function drawBinsSurf3D(painter, is_v7 = false) {
    }
 }
 
-export { assignFrame3DMethods, crete3DFrame,
+export { assignFrame3DMethods, crete3DFrame, build3dlatex,
          drawBinsLego, drawBinsError3D, drawBinsContour3D,
          drawBinsSurf3D, convertLegoBuf, createLegoGeom };

--- a/modules/hist/hist3d.mjs
+++ b/modules/hist/hist3d.mjs
@@ -1651,7 +1651,8 @@ function assignFrame3DMethods(fp) {
 async function crete3DFrame(painter, AxisPainterClass, render3d = constants.Render3D.None) {
    const fp = painter.getFramePainter(),
          o = painter.getOptions(),
-         histo = painter.getHisto();
+         histo = painter.getHisto(),
+         ndim = painter.getDimension();
 
    assignFrame3DMethods(fp);
 
@@ -1659,7 +1660,8 @@ async function crete3DFrame(painter, AxisPainterClass, render3d = constants.Rend
       fp.setAxesRanges(histo.fXaxis, painter.xmin, painter.xmax, histo.fYaxis, painter.ymin, painter.ymax, histo.fZaxis, painter.zmin, painter.zmax, painter);
       fp.set3DOptions(o);
       fp.drawXYZ(fp.toplevel, AxisPainterClass, {
-         ndim: painter.getDimension(),
+         ndim,
+         use_y_for_z: ndim === 1,
          hist_painter: painter,
          zmult: o.zmult ?? 1,
          zoom: (render3d !== constants.Render3D.None) && settings.Zooming,

--- a/modules/hist2d/THistPainter.mjs
+++ b/modules/hist2d/THistPainter.mjs
@@ -2064,7 +2064,7 @@ class THistPainter extends ObjectPainter {
       else {
          if (nlevels < 2)
             nlevels = gStyle.fNumberContours;
-         const pad = this.getPadPainter().getRootPad(true),
+         const pad = this.getPadPainter()?.getRootPad(true),
                logv = pad?.fLogv ?? ((ndim === 2) && pad?.fLogz);
 
          cntr.createNormal(nlevels, logv ?? 0, zminpositive);

--- a/modules/main.mjs
+++ b/modules/main.mjs
@@ -31,7 +31,7 @@ export { createGeoPainter, TGeoPainter } from './geom/TGeoPainter.mjs';
 
 export { loadOpenui5, registerForResize, setSaveFile, addMoveHandler } from './gui/utils.mjs';
 
-export { draw, redraw, makeSVG, makeImage, addDrawFunc, setDefaultDrawOpt } from './draw.mjs';
+export { draw, redraw, cleanup, build3d, makeSVG, makeImage, addDrawFunc, setDefaultDrawOpt } from './draw.mjs';
 
 export * from './gpad/TCanvasPainter.mjs';
 


### PR DESCRIPTION
Allows to create three.js object for supported ROOT classes

Supported:
* TH1, TH2, TH3
* TGeoManager
* TGraph2D
* TLatex

Provide demo in https://jsroot.gsi.de/dev/demo/hist_build3d.htm

Resolves #368 