### PR TITLE
Fix RNtuple processing

### DIFF
--- a/modules/rntuple.mjs
+++ b/modules/rntuple.mjs
@@ -1062,12 +1062,8 @@ async function readNextCluster(rntuple, selector) {
             // Ensure blob is a DataView
             if (!(blob instanceof DataView))
                throw new Error(`Invalid blob type for page ${i}: ${Object.prototype.toString.call(blob)}`);
-            const {
-               page,
-               colDesc
-            } = pages[i],
-                field = builder.fieldDescriptors[colDesc.fieldId],
-                values = builder.deserializePage(blob, colDesc, page);
+            const colDesc = pages[i].colDesc,
+                  values = builder.deserializePage(blob, colDesc, pages[i].page);
 
             // Support multiple representations (e.g., string fields with offsets + payload)
             if (!rntuple._clusterData[colDesc.index])


### PR DESCRIPTION
1. Each cluster can have several pages which has to be properly processed. Up to now only first page were analyzed
2. Process all clusters - not only very first
3. Use column index to store decoded data - simplify processing of std::string data

This fixes multiple problems with RNtuple reading.
But it is still very inefficient - while many similar actions performed for each entry.
But make this PR first which can be backported to 7.10