### PR TITLE
Add @vite-ignore to dynamic imports to silence Vite/Rollup warnings

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -2,6 +2,7 @@
 
 ## Changes in dev
 1. Add textendash and textemdash `TLatex` symbols #407
+1. Add `@vite-ignore` comment to dynamic imports to suppress Vite/Rollup analysis warnings
 1. Let store canvas as html file via context menu
 1. Improve `TGraph` update
 1. When draw TH2/TF2 with "surf same" draw option, only lines are drawn

--- a/modules/core.mjs
+++ b/modules/core.mjs
@@ -1137,7 +1137,7 @@ async function injectCode(code) {
       }).then(_fs => {
          fs = _fs;
          fs.writeFileSync(name, code);
-         return import(/* webpackIgnore: true */ 'file://' + name);
+         return import(/* webpackIgnore: true */ /* @vite-ignore */ 'file://' + name);
       }).finally(() => fs.unlinkSync(name));
    }
 
@@ -1179,7 +1179,7 @@ async function loadModules(arg) {
       arg = arg.split(';');
    if (!arg.length)
       return true;
-   return import(/* webpackIgnore: true */ arg.shift()).then(() => loadModules(arg));
+   return import(/* webpackIgnore: true */ /* @vite-ignore */ arg.shift()).then(() => loadModules(arg));
 }
 
 /** @summary Load script or CSS file into the browser
@@ -1218,7 +1218,7 @@ async function loadScript(url) {
       if (url.indexOf('./') === 0)
          return import('fs').then(fs => injectCode(fs.readFileSync(url)));
 
-      return import(/* webpackIgnore: true */ url);
+      return import(/* webpackIgnore: true */ /* @vite-ignore */ url);
    }
 
    const match_url = src => {

--- a/modules/gui/HierarchyPainter.mjs
+++ b/modules/gui/HierarchyPainter.mjs
@@ -3212,7 +3212,7 @@ class HierarchyPainter extends BasePainter {
          case 'draw_tree': return import('../draw/TTree.mjs');
          case 'hierarchy': return { HierarchyPainter, markAsStreamerInfo };
       }
-      return import(/* webpackIgnore: true */ module);
+      return import(/* webpackIgnore: true */ /* @vite-ignore */ module);
    }
 
    /** @summary set cached object for gui drawing


### PR DESCRIPTION
When JSROOT is bundled by Vite/Rollup-based tooling (e.g. the Angular 17+ dev server), the runtime-URL dynamic imports produce warnings like:

```
The above dynamic import cannot be analyzed by Vite.
See https://github.com/rollup/plugins/tree/master/packages/dynamic-import-vars#limitations ...
If this is intended to be left as-is, you can use the /* @vite-ignore */ comment inside the import() call to suppress this warning.
```

These imports (in `injectCode`, `loadModules`, `loadScript` in `modules/core.mjs`, and the module loader in `modules/gui/HierarchyPainter.mjs`) are intentionally dynamic — the URL is only known at runtime — which is exactly the case the `/* @vite-ignore */` comment exists for. This PR adds it alongside the existing `/* webpackIgnore: true */` comment; the two coexist and each bundler reads its own.

No behavior change: `node -e "import('./modules/core.mjs')"` loads fine, and the comments are ignored by browsers/Node.

Reported downstream by the Phoenix event display (HSF/phoenix#902), which consumes jsroot through Angular's Vite-based builder.

Also added a line to `changes.md`.