### PR TITLE
[ntuple] Fix precision of 32 bit float in rntuple_test32

### DIFF
--- a/demo/node/rntuple_test32.js
+++ b/demo/node/rntuple_test32.js
@@ -4,10 +4,17 @@ import { readFileSync } from 'fs';
 
 
 // convert float to hex representation based on IEEE-754 and C99 standard
-function floatToHex(num)
+function floatToHex(num, field)
 {
    if (num === 0)
       return (Object.is(num, -0) ? '-' : '') + '0x0p+0';
+
+   // convert num to Float32 for correct precision
+   if (field.startsWith("Float")) {
+      const tmp = new DataView(new ArrayBuffer(4));
+      tmp.setFloat32(0, num, false);
+      num = tmp.getFloat32(0, false);
+   }
 
    const buf = new ArrayBuffer(8), // 8 Byte == 64 Bit
          view = new DataView(buf);
@@ -59,7 +66,7 @@ async function read_file(input_root = 'rntuple_test32.root', input_ref = 'rntupl
    selector.Process = function(entryIndex) {
       for (const field of fields) {
          try {
-            const value = floatToHex(this.tgtobj[field]), expected = original[entryIndex][field];
+            const value = floatToHex(this.tgtobj[field], field), expected = original[entryIndex][field];
 
             if (value !== expected) {
                console.error(`FAILURE: ${field} at entry ${entryIndex} expected ${expected},`+

--- a/demo/node/rntuple_test32.json
+++ b/demo/node/rntuple_test32.json
@@ -1,15 +1,15 @@
 [
   {
     "FloatReal32Quant1": "-0x1p+0",
-    "FloatReal32Quant8": "-0x1.fdfdfdfdfdfep-2",
-    "FloatReal32Quant32": "0x1.0000000a1516p-2",
+    "FloatReal32Quant8": "-0x1.fdfdfep-2",
+    "FloatReal32Quant32": "0x1p-2",
     "DoubleReal32Quant1": "0x1p+0",
     "DoubleReal32Quant20": "0x1p+0",
     "DoubleReal32Quant32": "0x1.000000118p+1"
   },
   {
     "FloatReal32Quant1": "0x1p+0",
-    "FloatReal32Quant8": "0x1.0101010101p-8",
+    "FloatReal32Quant8": "0x1.010102p-8",
     "FloatReal32Quant32": "0x1.921fbp-31",
     "DoubleReal32Quant1": "0x1p+0",
     "DoubleReal32Quant20": "0x1.00001p-20",
@@ -17,7 +17,7 @@
   },
   {
     "FloatReal32Quant1": "0x1p+0",
-    "FloatReal32Quant8": "0x1.0101010101p-8",
+    "FloatReal32Quant8": "0x1.010102p-8",
     "FloatReal32Quant32": "0x1.921fbp-31",
     "DoubleReal32Quant1": "0x1p+0",
     "DoubleReal32Quant20": "0x1.00001p-20",


### PR DESCRIPTION
**⚠️ WARNING: Please change the base target branch from 'master' to 'dev' before submitting!**


# This Pull request:


## Changes:
Put `num` in Float32 buffer if it was written as a 32 bit float.

## Fixes:
Avoid excessive precision of 64 bit float.

