### PR TITLE
[ntuple] Process empty cluster

### DIFF
--- a/modules/rntuple.mjs
+++ b/modules/rntuple.mjs
@@ -711,7 +711,7 @@ async function readHeaderFooter(tuple) {
       // Deserialize Page List. Get byte range of each cluster group
       const groups = tuple.builder.clusterGroups;
       if (!groups?.length)
-         throw new Error('No cluster groups found');
+         return tuple.builder; // process RNTuples with no cluster groups
 
       const ranges = [];
       for (const g of groups) {
@@ -1561,6 +1561,10 @@ async function rntupleProcess(rntuple, selector, args = {}) {
          const item = addFieldReading(builder, field, tgtname);
          handle.items.push(item);
       }
+
+      // no entries for empty clusters
+      if (builder.clusterSummaries === undefined)
+         return selector;
 
       // calculate number of entries
       builder.clusterSummaries.forEach(summary => { handle.lastentry += summary.numEntries; });


### PR DESCRIPTION
# This Pull request:


## Changes:
Don't throw errors for empty clusters but skip entry processing.
## Fixes:
JSROOT is now capable of reading RNTuples with empty clusters.

